### PR TITLE
fix: message `topic` usage

### DIFF
--- a/imports-request-reply.md
+++ b/imports-request-reply.md
@@ -73,14 +73,14 @@ This allows the component to perform request/reply messaging patterns.</p>
 <li><a id="constructor_message.0"></a> own&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_topic"></a><code>[method]message.topic: func</code></h4>
-<p>The topic/subject/channel this message was received on</p>
+<p>The topic/subject/channel this message was received on, if any</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_message_topic.self"></a><code>self</code>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="method_message_topic.0"></a> <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
+<li><a id="method_message_topic.0"></a> option&lt;<a href="#topic"><a href="#topic"><code>topic</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_content_type"></a><code>[method]message.content-type: func</code></h4>
 <p>An optional content-type describing the format of the data in the message. This is
@@ -168,6 +168,9 @@ included it as a core interface.</p>
 #### <a id="error"></a>`type error`
 [`error`](#error)
 <p>
+#### <a id="topic"></a>`type topic`
+[`topic`](#topic)
+<p>
 #### <a id="request_options"></a>`resource request-options`
 <h2>Options for a request/reply operation. This is a resource to allow for future expansion of
 options.</h2>
@@ -208,6 +211,7 @@ return the list of messages received up to that point.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="request.c"></a><code>c</code>: borrow&lt;<a href="#client"><a href="#client"><code>client</code></a></a>&gt;</li>
+<li><a id="request.topic"></a><a href="#topic"><code>topic</code></a>: <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
 <li><a id="request.message"></a><a href="#message"><code>message</code></a>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 <li><a id="request.options"></a><code>options</code>: option&lt;own&lt;<a href="#request_options"><a href="#request_options"><code>request-options</code></a></a>&gt;&gt;</li>
 </ul>

--- a/imports.md
+++ b/imports.md
@@ -72,14 +72,14 @@ It includes the <code>producer</code> interface for sending messages.</p>
 <li><a id="constructor_message.0"></a> own&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_topic"></a><code>[method]message.topic: func</code></h4>
-<p>The topic/subject/channel this message was received on</p>
+<p>The topic/subject/channel this message was received on, if any</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_message_topic.self"></a><code>self</code>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="method_message_topic.0"></a> <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
+<li><a id="method_message_topic.0"></a> option&lt;<a href="#topic"><a href="#topic"><code>topic</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_content_type"></a><code>[method]message.content-type: func</code></h4>
 <p>An optional content-type describing the format of the data in the message. This is

--- a/messaging-core.md
+++ b/messaging-core.md
@@ -77,14 +77,14 @@ enabling the component to handle incoming messages without request/reply capabil
 <li><a id="constructor_message.0"></a> own&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_topic"></a><code>[method]message.topic: func</code></h4>
-<p>The topic/subject/channel this message was received on</p>
+<p>The topic/subject/channel this message was received on, if any</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_message_topic.self"></a><code>self</code>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="method_message_topic.0"></a> <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
+<li><a id="method_message_topic.0"></a> option&lt;<a href="#topic"><a href="#topic"><code>topic</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_content_type"></a><code>[method]message.content-type: func</code></h4>
 <p>An optional content-type describing the format of the data in the message. This is

--- a/messaging-request-reply.md
+++ b/messaging-request-reply.md
@@ -79,14 +79,14 @@ handling incoming messages with request/reply capabilities.</p>
 <li><a id="constructor_message.0"></a> own&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_topic"></a><code>[method]message.topic: func</code></h4>
-<p>The topic/subject/channel this message was received on</p>
+<p>The topic/subject/channel this message was received on, if any</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_message_topic.self"></a><code>self</code>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="method_message_topic.0"></a> <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
+<li><a id="method_message_topic.0"></a> option&lt;<a href="#topic"><a href="#topic"><code>topic</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_message_content_type"></a><code>[method]message.content-type: func</code></h4>
 <p>An optional content-type describing the format of the data in the message. This is
@@ -174,6 +174,9 @@ included it as a core interface.</p>
 #### <a id="error"></a>`type error`
 [`error`](#error)
 <p>
+#### <a id="topic"></a>`type topic`
+[`topic`](#topic)
+<p>
 #### <a id="request_options"></a>`resource request-options`
 <h2>Options for a request/reply operation. This is a resource to allow for future expansion of
 options.</h2>
@@ -214,6 +217,7 @@ return the list of messages received up to that point.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="request.c"></a><code>c</code>: borrow&lt;<a href="#client"><a href="#client"><code>client</code></a></a>&gt;</li>
+<li><a id="request.topic"></a><a href="#topic"><code>topic</code></a>: <a href="#topic"><a href="#topic"><code>topic</code></a></a></li>
 <li><a id="request.message"></a><a href="#message"><code>message</code></a>: borrow&lt;<a href="#message"><a href="#message"><code>message</code></a></a>&gt;</li>
 <li><a id="request.options"></a><code>options</code>: option&lt;own&lt;<a href="#request_options"><a href="#request_options"><code>request-options</code></a></a>&gt;&gt;</li>
 </ul>

--- a/wit/request-reply.wit
+++ b/wit/request-reply.wit
@@ -3,7 +3,7 @@
 /// request/reply. However, request/reply is a very common pattern in messaging and as such, we have
 /// included it as a core interface.
 interface request-reply {
-    use types.{client, message, error};
+    use types.{client, message, error, topic};
 
     /// Options for a request/reply operation. This is a resource to allow for future expansion of
     /// options.
@@ -31,7 +31,7 @@ interface request-reply {
     /// error, (2) if the maximum expected number of replies were received before timeout, return
     /// the list of messages, or (3) if the timeout is reached before the expected number of replies,
     /// return the list of messages received up to that point.
-    request: func(c: borrow<client>, message: borrow<message>, options: option<request-options>) -> result<list<message>, error>;
+    request: func(c: borrow<client>, topic: topic, message: borrow<message>, options: option<request-options>) -> result<list<message>, error>;
 
     /// Replies to the given message with the given response message. The details of which topic
     /// the message is sent to is up to the implementation. This allows for reply-to details to be

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -26,8 +26,8 @@ interface types {
     /// A message with a binary payload and additional information
     resource message {
         constructor(data: list<u8>);
-        /// The topic/subject/channel this message was received on
-        topic: func() -> topic;
+        /// The topic/subject/channel this message was received on, if any
+        topic: func() -> option<topic>;
         /// An optional content-type describing the format of the data in the message. This is 
         /// sometimes described as the "format" type
         content-type: func() -> option<string>;


### PR DESCRIPTION
- Topic can only ever be set by the host, for messages originating in the guest it cannot be set, therefore make the getter return an optional value for the cases where the is no topic to return.
- Take a `topic` as a parameter in `request`, as outlined above, the only way for the guest to specify a topic is by passing it as a parameter